### PR TITLE
Feature: jwt 디코딩을 통한 사용자 권한 추출 및 해당 권한을 통한 경로 접근과 보호기능

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@heroicons/react": "^2.1.5",
         "@reduxjs/toolkit": "^2.3.0",
         "axios": "^1.7.7",
+        "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.2",
@@ -4179,6 +4180,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@heroicons/react": "^2.1.5",
     "@reduxjs/toolkit": "^2.3.0",
     "axios": "^1.7.7",
+    "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.2",

--- a/src/components/admin-route/AdminRoute.tsx
+++ b/src/components/admin-route/AdminRoute.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { jwtDecode }from 'jwt-decode';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../store'; // 프로젝트의 Redux store 경로에 맞게 수정
+
+interface DecodedToken {
+    roles: string[];
+}
+
+const AdminRoute = ({ children }: { children: React.ReactNode }) => {
+    const token = useSelector((state: RootState) => state.auth.token);
+
+    if (!token) {
+        // 로그인하지 않은 사용자는 로그인 페이지로 리다이렉트
+        return <Navigate to="/login" replace />;
+    }
+
+    try {
+        // JWT에서 roles 정보 추출
+        const decoded: DecodedToken = jwtDecode(token);
+        if (decoded.roles.includes('ROLE_ADMIN')) {
+            return <>{children}</>;
+        } else {
+            // 관리자가 아닌 경우 접근 차단
+            alert('접근 권한이 없습니다.');
+            return <Navigate to="/" replace />;
+        }
+    } catch (error) {
+        console.error('JWT 디코딩 오류:', error);
+        return <Navigate to="/login" replace />;
+    }
+};
+
+export default AdminRoute;

--- a/src/components/admin-route/index.ts
+++ b/src/components/admin-route/index.ts
@@ -1,0 +1,3 @@
+import AdminRoute from "./AdminRoute";
+
+export default AdminRoute;

--- a/src/components/ex-setlist/ExSetlist.tsx
+++ b/src/components/ex-setlist/ExSetlist.tsx
@@ -26,7 +26,7 @@ const ExSetlist: React.FC<ExSetlistProps> = ({ newConcertId }) => {
       setLoading(true);
       setError(null); // 이전 에러 상태 초기화
       try {
-        const response = await axios.get(`/api/concerts/${newConcertId}/predicted-setlist`); // newConcertId를 사용한 API 호출
+        const response = await axios.get(`/api/new-concerts/${newConcertId}/predicted-setlist`); // newConcertId를 사용한 API 호출
         console.log('Fetched setlist data:', response.data);
 
         if (Array.isArray(response.data)) {

--- a/src/components/login-form/LoginForm.tsx
+++ b/src/components/login-form/LoginForm.tsx
@@ -52,7 +52,7 @@ const LoginForm = () => {
       // 페이지 이동 지연 로그인 확인 위해서 일부러 했음
       setTimeout(() => {
         console.log('페이지 이동');
-        navigate('/');
+        // navigate('/');
       }, 100);
     } catch (error) {
       if (axios.isAxiosError(error)) {

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const AdminPage = () => {
+    return (
+        <div className="w-full h-screen flex items-center justify-center bg-gray-100">
+            <h1 className="text-3xl font-bold text-black">관리자 페이지</h1>
+        </div>
+    );
+};
+
+export default AdminPage;

--- a/src/pages/admin/index.ts
+++ b/src/pages/admin/index.ts
@@ -1,0 +1,3 @@
+import AdminPage from './AdminPage';
+
+export default AdminPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,7 +19,8 @@ import ArtistPage from '@/pages/artist/ArtistPage';
 import MyPage from '@/pages/my';
 import BoardPage from '@/pages/board';
 import SearchPage from '@/pages/search';
-
+import AdminPage from "@/pages/admin";
+import AdminRoute from "../components/admin-route/AdminRoute";
 
 export const router = createBrowserRouter([
   {
@@ -94,6 +95,14 @@ export const router = createBrowserRouter([
     path: "/search", // 검색 페이지 추가
     element: <SearchPage/>,
   },
+  {
+    path: '/admin',
+    element: (
+        <AdminRoute>
+          <AdminPage />
+        </AdminRoute>
+    ),
+  }
 ]);
 
 export default router;

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { jwtDecode } from "jwt-decode";
 
 // 네트워크 api 에서 받아오는 payload 참고 후 맞춰서 작성
 interface LoginPayload {
@@ -12,6 +13,7 @@ interface AuthState {
   token: string | null;
   refreshToken: string | null;
   nickname: string | null;
+  role: string | null;
 }
 
 // Helper functions
@@ -25,12 +27,29 @@ export const removeToken = () => {
   localStorage.removeItem('nickname'); // 로그아웃 시 닉네임도 제거
 };
 
+interface DecodedToken {
+  roles: string[];
+  sub: string;
+  exp: number;
+}
+
 // Initial state
 const initialState: AuthState = {
   isLoggedIn: !!getToken(), // 저장된 토큰으로 초기 상태 설정
   token: getToken(),
   refreshToken: getRefreshToken(),
   nickname: getNickname(), // localStorage에서 nickname을 가져옴
+  role: (() => {
+    try {
+      const token = getToken();
+      if (!token) return null; // 토큰이 없으면 null
+      const decoded: DecodedToken = jwtDecode<DecodedToken>(token);
+      return decoded.roles ? decoded.roles[0] : null; // roles 확인
+    } catch (error) {
+      console.error('JWT 디코딩 오류:', error);
+      return null; // 디코딩 실패 시 null
+    }
+  })(),
 };
 
 // Redux Slice
@@ -43,6 +62,11 @@ const authSlice = createSlice({
       state.token = action.payload.token;
       state.refreshToken = action.payload.refreshToken || null;
       state.nickname = action.payload.nickname; // nickname을 상태에 저장
+
+      // JWT에서 role 추출
+      const decoded: DecodedToken = jwtDecode(action.payload.token);
+      state.role = decoded.roles[0];
+
       setToken(action.payload.token);
       localStorage.setItem('nickname', action.payload.nickname); // nickname도 localStorage에 저장
     },
@@ -51,6 +75,7 @@ const authSlice = createSlice({
       state.token = null;
       state.refreshToken = null;
       state.nickname = null; // 로그아웃 시 nickname도 null 처리
+      state.role = null; // 역할 정보도 초기화
       removeToken();
     },
   },


### PR DESCRIPTION
[feat: jwt 디코딩으로 권한을 확인 후 관리자인 경우 관리자페이지 접속가능]
- jwt-decode 추가 : 토큰 디코딩 용
- Slice 에 roles 추가
- AdminRoute.tsx 를 통해 관리자 권한을 가진 사용자만 /admin 경로에 접근할 수 있도록 보호 함

[feat: 임시 관리자 페이지 추가]

[fix: 예상 셋리스트 불러오는 엔드포인트 수정]
기존 : /api/concerts/${newConcertId}/predicted-setlist
변경 : /api/new-concerts/${newConcertId}/predicted-setlist