### PR TITLE
feat: 관리자 페이지 기능 구현 & 비 로그인시 리다이렉트 처리 & 즐겨찾기 관련 기능 추가

### DIFF
--- a/src/components/admin/ArtistCrud.tsx
+++ b/src/components/admin/ArtistCrud.tsx
@@ -1,0 +1,249 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+
+const ArtistCrud = () => {
+    const [artists, setArtists] = useState([]);
+    const [formData, setFormData] = useState({
+        mbid: "",
+        name: "",
+        krName: "",
+        imgUrl: "",
+        snsUrl: "",
+        mediaUrl: "",
+    });
+    const [isEditing, setIsEditing] = useState(false);
+    const [editArtistId, setEditArtistId] = useState<number | null>(null);
+
+    // 아티스트 목록 가져오기
+    const fetchArtists = async () => {
+        try {
+            const response = await axios.get("/api/artists");
+            setArtists(response.data);
+        } catch (error) {
+            console.error("아티스트 조회 실패:", error);
+        }
+    };
+
+    useEffect(() => {
+        fetchArtists();
+    }, []);
+
+    // 입력 필드 변경 처리
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target;
+        setFormData({ ...formData, [name]: value });
+    };
+
+    // 아티스트 등록
+    const addArtist = async () => {
+        const token = localStorage.getItem('token');
+
+        try {
+            await axios.post("/api/admin/artist", formData,
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`, // JWT 토큰 추가
+                    },
+                }
+            );
+            fetchArtists();
+            resetForm();
+        } catch (error) {
+            console.error("아티스트 등록 실패:", error);
+        }
+    };
+
+    // 아티스트 수정
+    const updateArtist = async () => {
+        if (editArtistId === null) return;
+
+        // JWT 토큰 가져오기 (예: 로컬 스토리지 또는 쿠키에서)
+        const token = localStorage.getItem('token');
+
+        try {
+            await axios.put(
+                `/api/admin/artists/${editArtistId}`,
+                formData,
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`, // JWT 토큰 추가
+                    },
+                }
+            );
+            fetchArtists();
+            resetForm();
+        } catch (error) {
+            console.error("아티스트 수정 실패:", error);
+        }
+    };
+
+    // 수정 모드 진입
+    const startEditing = (artist: any) => {
+        setIsEditing(true);
+        setEditArtistId(artist.artistId);
+        setFormData({
+            mbid: artist.mbid,
+            name: artist.name,
+            krName: artist.krName,
+            imgUrl: artist.imgUrl,
+            snsUrl: artist.snsUrl,
+            mediaUrl: artist.mediaUrl,
+        });
+    };
+
+    // 수정 모드 취소
+    const cancelEditing = () => {
+        resetForm();
+    };
+
+    // 폼 초기화
+    const resetForm = () => {
+        setIsEditing(false);
+        setEditArtistId(null);
+        setFormData({
+            mbid: "",
+            name: "",
+            krName: "",
+            imgUrl: "",
+            snsUrl: "",
+            mediaUrl: "",
+        });
+    };
+
+    // 아티스트 삭제
+    const deleteArtist = async (id: number) => {
+        if (!window.confirm("정말 삭제하시겠습니까?")) return;
+
+        // JWT 토큰 가져오기 (예: 로컬 스토리지 또는 쿠키에서)
+        const token = localStorage.getItem('token');
+
+        try {
+            await axios.delete(
+                `/api/admin/artists/${id}`,
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`, // JWT 토큰 추가
+                    },
+                }
+            );
+            fetchArtists();
+        } catch (error) {
+            console.error("아티스트 삭제 실패:", error);
+        }
+    };
+
+
+    return (
+        <div>
+            <h2 className="text-lg font-semibold mb-4">아티스트 관리</h2>
+            <div className="mb-4">
+                <input
+                    type="text"
+                    name="mbid"
+                    value={formData.mbid}
+                    placeholder="MBID"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="name"
+                    value={formData.name}
+                    placeholder="이름"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="krName"
+                    value={formData.krName}
+                    placeholder="한글 이름"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="imgUrl"
+                    value={formData.imgUrl}
+                    placeholder="이미지 URL"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="snsUrl"
+                    value={formData.snsUrl}
+                    placeholder="SNS URL"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="mediaUrl"
+                    value={formData.mediaUrl}
+                    placeholder="미디어 URL"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <div className="flex space-x-2">
+                    <button
+                        onClick={isEditing ? updateArtist : addArtist}
+                        className={`${
+                            isEditing ? "bg-yellow-500" : "bg-blue-500"
+                        } text-white px-4 py-2`}
+                    >
+                        {isEditing ? "수정" : "등록"}
+                    </button>
+                    {isEditing && (
+                        <button
+                            onClick={cancelEditing}
+                            className="bg-gray-500 text-white px-4 py-2"
+                        >
+                            취소
+                        </button>
+                    )}
+                </div>
+            </div>
+            <table className="w-full border-collapse border">
+                <thead>
+                <tr>
+                    <th className="border px-4 py-2">ID</th>
+                    <th className="border px-4 py-2">MBID</th>
+                    <th className="border px-4 py-2">이름</th>
+                    <th className="border px-4 py-2">한글 이름</th>
+                    <th className="border px-4 py-2">수정</th>
+                    <th className="border px-4 py-2">삭제</th>
+                </tr>
+                </thead>
+                <tbody>
+                {artists.map((artist: any) => (
+                    <tr key={artist.artistId}>
+                        <td className="border px-4 py-2">{artist.artistId}</td>
+                        <td className="border px-4 py-2">{artist.mbid}</td>
+                        <td className="border px-4 py-2">{artist.name}</td>
+                        <td className="border px-4 py-2">{artist.krName}</td>
+                        <td className="border px-4 py-2">
+                            <button
+                                onClick={() => startEditing(artist)}
+                                className="bg-green-500 text-white px-2 py-1"
+                            >
+                                수정
+                            </button>
+                        </td>
+                        <td className="border px-4 py-2">
+                            <button
+                                onClick={() => deleteArtist(artist.artistId)}
+                                className="bg-red-500 text-white px-2 py-1"
+                            >
+                                삭제
+                            </button>
+                        </td>
+                    </tr>
+                ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default ArtistCrud;

--- a/src/components/admin/ArtistSync.tsx
+++ b/src/components/admin/ArtistSync.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+import axios from "axios";
+
+const ArtistSync = () => {
+    const [mbid, setMbid] = useState("");
+
+    const syncArtistData = async () => {
+        // JWT 토큰 가져오기 (예: 로컬 스토리지 또는 쿠키에서)
+        const token = localStorage.getItem('token');
+
+        try {
+            await axios.post(
+                `/api/admin/artists/${mbid}/sync`,
+                {},
+                {
+                    headers: {
+                        Authorization: `Bearer ${token}`, // JWT 토큰 추가
+                    },
+                }
+            );
+            alert("데이터 동기화 성공");
+            setMbid("");
+        } catch (error) {
+            console.error("데이터 동기화 실패:", error);
+        }
+    };
+
+
+    return (
+        <div>
+            <h2 className="text-lg font-semibold mb-4">아티스트 데이터 동기화</h2>
+            <input
+                type="text"
+                value={mbid}
+                onChange={(e) => setMbid(e.target.value)}
+                placeholder="MBID 입력"
+                className="border p-2 mb-2 w-full"
+            />
+            <button onClick={syncArtistData} className="bg-green-500 text-white px-4 py-2">
+                동기화 요청
+            </button>
+        </div>
+    );
+};
+
+export default ArtistSync;

--- a/src/components/admin/ArtistTab.tsx
+++ b/src/components/admin/ArtistTab.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import ArtistCrud from "./ArtistCrud";
+import ArtistSync from "./ArtistSync";
+
+const ArtistTab = () => {
+    const [activeTab, setActiveTab] = useState<"crud" | "sync">("crud");
+
+    return (
+        <div className="p-4">
+            <div className="flex space-x-4 border-b mb-4">
+                <button
+                    className={`py-2 px-4 ${
+                        activeTab === "crud" ? "border-b-2 border-blue-500 text-blue-500" : ""
+                    }`}
+                    onClick={() => setActiveTab("crud")}
+                >
+                    아티스트 관리
+                </button>
+                <button
+                    className={`py-2 px-4 ${
+                        activeTab === "sync" ? "border-b-2 border-blue-500 text-blue-500" : ""
+                    }`}
+                    onClick={() => setActiveTab("sync")}
+                >
+                    데이터 동기화
+                </button>
+            </div>
+            <div>
+                {activeTab === "crud" && <ArtistCrud />}
+                {activeTab === "sync" && <ArtistSync />}
+            </div>
+        </div>
+    );
+};
+
+export default ArtistTab;

--- a/src/components/admin/ConcertCrud.tsx
+++ b/src/components/admin/ConcertCrud.tsx
@@ -1,0 +1,325 @@
+import React, { useState, useEffect } from "react";
+import axios from "axios";
+
+const ConcertCrud = () => {
+    const [concerts, setConcerts] = useState([]);
+    const [formData, setFormData] = useState({
+        artistId: "",
+        title: "",
+        subTitle: "",
+        startDate: "",
+        endDate: "",
+        venueName: "",
+        cityName: "",
+        countryName: "",
+        countryCode: "",
+        ticketPlatforms: "",
+        ticketUrl: "",
+        posterUrl: "",
+        genre: "",
+        concertStatus: "UPCOMING",
+    });
+    const [isEditing, setIsEditing] = useState(false);
+    const [editConcertId, setEditConcertId] = useState<number | null>(null);
+
+    // JWT 토큰 가져오기
+    const getToken = () => localStorage.getItem('token');
+
+    // 콘서트 목록 가져오기
+    const fetchConcerts = async () => {
+        try {
+            const response = await axios.get("/api/new-concerts", {
+                headers: {
+                    Authorization: `Bearer ${getToken()}`,
+                },
+            });
+            setConcerts(response.data);
+        } catch (error) {
+            console.error("콘서트 조회 실패:", error);
+        }
+    };
+
+    useEffect(() => {
+        fetchConcerts();
+    }, []);
+
+    // 입력 필드 변경 처리
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        const { name, value } = e.target;
+        setFormData({ ...formData, [name]: value });
+    };
+
+    // 콘서트 등록
+    const addConcert = async () => {
+        try {
+            await axios.post("/api/admin/new-concert", formData, {
+                headers: {
+                    Authorization: `Bearer ${getToken()}`,
+                },
+            });
+            fetchConcerts();
+            resetForm();
+        } catch (error) {
+            console.error("콘서트 등록 실패:", error);
+        }
+    };
+
+    // 콘서트 수정
+    const updateConcert = async () => {
+        if (editConcertId === null) return;
+        try {
+            await axios.put(`/api/admin/new-concert/${editConcertId}`, formData, {
+                headers: {
+                    Authorization: `Bearer ${getToken()}`,
+                },
+            });
+            fetchConcerts();
+            resetForm();
+        } catch (error) {
+            console.error("콘서트 수정 실패:", error);
+        }
+    };
+
+    // 수정 모드 진입
+    const startEditing = (concert: any) => {
+        setIsEditing(true);
+        setEditConcertId(concert.newConcertId);
+        setFormData({
+            artistId: concert.artistId,
+            title: concert.title,
+            subTitle: concert.subTitle,
+            startDate: concert.startDate,
+            endDate: concert.endDate,
+            venueName: concert.venueName,
+            cityName: concert.cityName,
+            countryName: concert.countryName,
+            countryCode: concert.countryCode,
+            ticketPlatforms: concert.ticketPlatforms,
+            ticketUrl: concert.ticketUrl,
+            posterUrl: concert.posterUrl,
+            genre: concert.genre,
+            concertStatus: concert.concertStatus,
+        });
+    };
+
+    // 수정 모드 취소
+    const cancelEditing = () => {
+        resetForm();
+    };
+
+    // 폼 초기화
+    const resetForm = () => {
+        setIsEditing(false);
+        setEditConcertId(null);
+        setFormData({
+            artistId: "",
+            title: "",
+            subTitle: "",
+            startDate: "",
+            endDate: "",
+            venueName: "",
+            cityName: "",
+            countryName: "",
+            countryCode: "",
+            ticketPlatforms: "",
+            ticketUrl: "",
+            posterUrl: "",
+            genre: "",
+            concertStatus: "UPCOMING",
+        });
+    };
+
+    // 콘서트 삭제
+    const deleteConcert = async (id: number) => {
+        if (!window.confirm("정말 삭제하시겠습니까?")) return;
+        try {
+            await axios.delete(`/api/admin/new-concerts/${id}`, {
+                headers: {
+                    Authorization: `Bearer ${getToken()}`,
+                },
+            });
+            fetchConcerts();
+        } catch (error) {
+            console.error("콘서트 삭제 실패:", error);
+        }
+    };
+
+    return (
+        <div>
+            <h2 className="text-lg font-semibold mb-4">콘서트 관리</h2>
+            <div className="mb-4">
+                <input
+                    type="text"
+                    name="artistId"
+                    value={formData.artistId}
+                    placeholder="아티스트 ID"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="title"
+                    value={formData.title}
+                    placeholder="콘서트 제목"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="subTitle"
+                    value={formData.subTitle}
+                    placeholder="콘서트 부제"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="date"
+                    name="startDate"
+                    value={formData.startDate}
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="date"
+                    name="endDate"
+                    value={formData.endDate}
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="venueName"
+                    value={formData.venueName}
+                    placeholder="공연장 이름"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="cityName"
+                    value={formData.cityName}
+                    placeholder="도시 이름"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="countryName"
+                    value={formData.countryName}
+                    placeholder="국가 이름"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="countryCode"
+                    value={formData.countryCode}
+                    placeholder="국가 코드"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="ticketPlatforms"
+                    value={formData.ticketPlatforms}
+                    placeholder="티켓 플랫폼"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="ticketUrl"
+                    value={formData.ticketUrl}
+                    placeholder="티켓 URL"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="posterUrl"
+                    value={formData.posterUrl}
+                    placeholder="포스터 URL"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <input
+                    type="text"
+                    name="genre"
+                    value={formData.genre}
+                    placeholder="장르"
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                />
+                <select
+                    name="concertStatus"
+                    value={formData.concertStatus}
+                    onChange={handleInputChange}
+                    className="border p-2 mb-2 w-full"
+                >
+                    <option value="UPCOMING">UPCOMING</option>
+                    <option value="COMPLETED">COMPLETED</option>
+                </select>
+                <button
+                    onClick={isEditing ? updateConcert : addConcert}
+                    className={`${
+                        isEditing ? "bg-yellow-500" : "bg-blue-500"
+                    } text-white px-4 py-2`}
+                >
+                    {isEditing ? "수정" : "등록"}
+                </button>
+                {isEditing && (
+                    <button
+                        onClick={cancelEditing}
+                        className="bg-gray-500 text-white px-4 py-2 ml-2"
+                    >
+                        취소
+                    </button>
+                )}
+            </div>
+            <table className="w-full border-collapse border">
+                <thead>
+                <tr>
+                    <th className="border px-4 py-2">ID</th>
+                    <th className="border px-4 py-2">아티스트 ID</th>
+                    <th className="border px-4 py-2">아티스트 이름</th>
+                    <th className="border px-4 py-2">시작 날짜</th>
+                    <th className="border px-4 py-2">종료 날짜</th>
+                    <th className="border px-4 py-2">상태</th>
+                    <th className="border px-4 py-2">수정</th>
+                    <th className="border px-4 py-2">삭제</th>
+                </tr>
+                </thead>
+                <tbody>
+                {concerts.map((concert: any) => (
+                    <tr key={concert.newConcertId}>
+                        <td className="border px-4 py-2">{concert.newConcertId}</td>
+                        <td className="border px-4 py-2">{concert.artistId}</td>
+                        <td className="border px-4 py-2">{concert.artistName}</td>
+                        <td className="border px-4 py-2">{concert.startDate}</td>
+                        <td className="border px-4 py-2">{concert.endDate}</td>
+                        <td className="border px-4 py-2">{concert.concertStatus}</td>
+                        <td className="border px-4 py-2">
+                            <button
+                                onClick={() => startEditing(concert)}
+                                className="bg-green-500 text-white px-2 py-1"
+                            >
+                                수정
+                            </button>
+                        </td>
+                        <td className="border px-4 py-2">
+                            <button
+                                onClick={() => deleteConcert(concert.newConcertId)}
+                                className="bg-red-500 text-white px-2 py-1"
+                            >
+                                삭제
+                            </button>
+                        </td>
+                    </tr>
+                ))}
+                </tbody>
+            </table>
+        </div>
+    );
+};
+
+export default ConcertCrud;

--- a/src/components/admin/ConcertTab.tsx
+++ b/src/components/admin/ConcertTab.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import ConcertCrud from "./ConcertCrud";
+import PredictSetlist from "./PredictSetlist";
+
+const ConcertTab = () => {
+    const [activeTab, setActiveTab] = useState<"crud" | "predict">("crud");
+
+    return (
+        <div className="p-4">
+            <div className="flex space-x-4 border-b mb-4">
+                <button
+                    className={`py-2 px-4 ${
+                        activeTab === "crud" ? "border-b-2 border-blue-500 text-blue-500" : ""
+                    }`}
+                    onClick={() => setActiveTab("crud")}
+                >
+                    콘서트 관리
+                </button>
+                <button
+                    className={`py-2 px-4 ${
+                        activeTab === "predict" ? "border-b-2 border-blue-500 text-blue-500" : ""
+                    }`}
+                    onClick={() => setActiveTab("predict")}
+                >
+                    예상 셋리스트
+                </button>
+            </div>
+            <div>
+                {activeTab === "crud" && <ConcertCrud />}
+                {activeTab === "predict" && <PredictSetlist />}
+            </div>
+        </div>
+    );
+};
+
+export default ConcertTab;

--- a/src/components/admin/PredictSetlist.tsx
+++ b/src/components/admin/PredictSetlist.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import axios from "axios";
+
+const PredictSetlist = () => {
+    const [artistId, setArtistId] = useState("");
+    const [newConcertId, setNewConcertId] = useState("");
+
+    const predictSetlist = async () => {
+        // JWT 토큰 가져오기 (예: 로컬 스토리지에서)
+        const token = localStorage.getItem("token");
+
+        try {
+            await axios.post(
+                `/api/admin/artists/${artistId}/predict-setlist`,
+                null,
+                {
+                    params: { newConcertId },
+                    headers: {
+                        Authorization: `Bearer ${token}`, // JWT 토큰 추가
+                    },
+                }
+            );
+            alert("예상 셋리스트 생성 성공");
+        } catch (error) {
+            console.error("예상 셋리스트 생성 실패:", error);
+        }
+    };
+
+    return (
+        <div>
+            <h2 className="text-lg font-semibold mb-4">예상 셋리스트 생성</h2>
+            <input
+                type="text"
+                value={artistId}
+                onChange={(e) => setArtistId(e.target.value)}
+                placeholder="아티스트 ID"
+                className="border p-2 mb-2 w-full"
+            />
+            <input
+                type="text"
+                value={newConcertId}
+                onChange={(e) => setNewConcertId(e.target.value)}
+                placeholder="콘서트 ID"
+                className="border p-2 mb-2 w-full"
+            />
+            <button onClick={predictSetlist} className="bg-green-500 text-white px-4 py-2">
+                생성 요청
+            </button>
+        </div>
+    );
+};
+
+export default PredictSetlist;

--- a/src/components/artist-like/ArtistLike.tsx
+++ b/src/components/artist-like/ArtistLike.tsx
@@ -56,9 +56,11 @@ const ArtistLike: React.FC<ArtistLikeProps> = ({ artistId }) => {
     try {
       if (favorite) {
         await apiRemoveArtistFavorite({ artistId, token });
+        setFavorite(false);
         dispatch(removeFavorite({ artistId }));
       } else {
         await apiAddArtistFavorite({ artistId, token });
+        setFavorite(true);
         const newFavorite = {
           favoriteId: Math.random(),
           artistId,

--- a/src/components/artist-like/ArtistLike.tsx
+++ b/src/components/artist-like/ArtistLike.tsx
@@ -14,12 +14,14 @@ import {
 } from '@/apis/favorites.api';
 import { HeartIcon as SolidHeartIcon } from '@heroicons/react/24/solid';
 import { HeartIcon as OutlineHeartIcon } from '@heroicons/react/24/outline';
+import { useNavigate } from 'react-router-dom';
 
 interface ArtistLikeProps {
   artistId: number;
 }
 
 const ArtistLike: React.FC<ArtistLikeProps> = ({ artistId }) => {
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const token = useSelector((state: RootState) => state.auth.token);
   const loading = useSelector((state: RootState) => state.artistlikes.loading);
@@ -48,6 +50,7 @@ const ArtistLike: React.FC<ArtistLikeProps> = ({ artistId }) => {
   const handleLikeToggle = async () => {
     if (!token) {
       alert('로그인이 필요합니다!');
+      navigate('/login');
       return;
     }
 

--- a/src/components/category-card/CategoryCard.tsx
+++ b/src/components/category-card/CategoryCard.tsx
@@ -1,11 +1,12 @@
 import sampleImg from '@/assets/images/sampleimg1.jpg';
+import { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 interface ListCardProps {
   concertId: number; // 추가된 concertId
   image: string;
   title: string;
-  name: string;
+  name: ReactNode;
   startDate: number[]; // 배열 형태로 수정
   endDate: number[];
 }

--- a/src/components/concert-like/ConcertLike.tsx
+++ b/src/components/concert-like/ConcertLike.tsx
@@ -14,12 +14,14 @@ import {
 } from '@/apis/favorites.api';
 import { HeartIcon as SolidHeartIcon } from '@heroicons/react/24/solid';
 import { HeartIcon as OutlineHeartIcon } from '@heroicons/react/24/outline';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertLikeProps {
   concertId: number;
 }
 
 const ConcertLike: React.FC<ConcertLikeProps> = ({ concertId }) => {
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const token = useSelector((state: RootState) => state.auth.token);
   const loading = useSelector((state: RootState) => state.concertlikes.loading);
@@ -48,6 +50,7 @@ const ConcertLike: React.FC<ConcertLikeProps> = ({ concertId }) => {
   const handleLikeToggle = async () => {
     if (!token) {
       alert('로그인이 필요합니다!');
+      navigate('/login');
       return;
     }
 

--- a/src/components/global-list-slide/GlobalListContents.tsx
+++ b/src/components/global-list-slide/GlobalListContents.tsx
@@ -42,6 +42,11 @@ const GlobalListContents: React.FC<GlobalListContentsProps> = ({ title }) => {
     fetchConcerts();
   }, [title]); // title 값이 변경될 때마다 호출
 
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
   return (
     <div className='flex flex-col w-full mx-auto h-auto py-[8px]'>
       {/* 상단 타이틀과 더보기 */}
@@ -71,7 +76,14 @@ const GlobalListContents: React.FC<GlobalListContentsProps> = ({ title }) => {
                 concertId={concert.newConcertId}
                 image={concert.posterUrl}
                 title={concert.title}
-                name={concert.krName}
+                name={
+                  <span
+                    className="text-[#8c8c8c]  cursor-pointer"
+                    onClick={(e) => handleArtistClick(concert.artistId, e)}
+                  >
+                    {concert.artistName}
+                  </span>
+                }
                 startDate={concert.startDate}
                 endDate={concert.endDate}
               />

--- a/src/components/my-artist/MyArtist.tsx
+++ b/src/components/my-artist/MyArtist.tsx
@@ -3,6 +3,7 @@ import MyItem from '../my-item';
 import { getUserFavorites } from '@/apis/favorites.api'; // 즐겨찾기 API 가져오기
 import { useSelector } from 'react-redux';
 import { RootState } from '@/store';
+import { useNavigate } from 'react-router-dom';
 
 interface MyArtistProps {
   isExpanded: boolean; // 더보기 상태를 받아옴
@@ -13,6 +14,7 @@ const MyArtist: React.FC<MyArtistProps> = ({ isExpanded }) => {
   const [loading, setLoading] = useState(false); // 로딩 상태
   const [error, setError] = useState<string | null>(null); // 에러 상태
   const token = useSelector((state: RootState) => state.auth.token); // Redux에서 토큰 가져오기
+  const navigate = useNavigate(); // 페이지 이동을 위한 훅
 
   useEffect(() => {
     const fetchFavorites = async () => {
@@ -53,10 +55,18 @@ const MyArtist: React.FC<MyArtistProps> = ({ isExpanded }) => {
     ? filteredArtists
     : filteredArtists.slice(0, 2);
 
+  const handleItemClick = (artistId: string) => {
+    navigate(`/artist/${artistId}`); // artist/artistId로 이동
+  };
+
   return (
     <div className="w-full">
       {visibleData.map((artist) => (
-        <div key={artist.id}>
+        <div
+          key={artist.artistId} // 여기서 artistId를 사용
+          onClick={() => handleItemClick(artist.artistId)} // artistId를 클릭 이벤트로 사용
+          className="cursor-pointer" // 클릭 가능한 UI 표시를 위한 스타일
+        >
           <MyItem 
             name={artist.artistName} 
             imgurl={artist.imgUrl} // 이미지 URL 전달

--- a/src/components/my-concert/Mycocnert.tsx
+++ b/src/components/my-concert/Mycocnert.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom'; // 페이지 이동을 위한 훅
 import MyItem from '../my-item';
 import { getUserFavorites } from '@/apis/favorites.api';
 import { useSelector } from 'react-redux';
@@ -13,10 +14,13 @@ const MyConcert: React.FC<MyConcertProps> = ({ isExpanded }) => {
   const [loading, setLoading] = useState(false); // 로딩 상태
   const [error, setError] = useState<string | null>(null); // 에러 상태
 
+  const navigate = useNavigate(); // 페이지 이동을 위한 훅
+
   // Redux에서 토큰 가져오기
   const token = useSelector((state: RootState) => state.auth.token);
 
   // 즐겨찾기 데이터를 가져오는 함수
+  useEffect(() => {
   const fetchFavorites = async () => {
     if (!token) {
       setError('로그인이 필요합니다.');
@@ -38,7 +42,6 @@ const MyConcert: React.FC<MyConcertProps> = ({ isExpanded }) => {
   };
 
   // 컴포넌트가 처음 마운트되거나 토큰이 변경될 때 데이터를 가져옴
-  useEffect(() => {
     fetchFavorites();
   }, [token]);
 
@@ -60,10 +63,19 @@ const MyConcert: React.FC<MyConcertProps> = ({ isExpanded }) => {
   // 표시할 데이터 (isExpanded에 따라 조절)
   const visibleData = isExpanded ? filteredData : filteredData.slice(0, 2);
 
+  // 특정 아이템 클릭 시 concert/newConcertId로 이동하는 함수
+  const handleItemClick = (newConcertId: string) => {
+    navigate(`/concert/${newConcertId}`); // 해당 경로로 이동
+  };
+
   return (
     <div className="w-full">
       {visibleData.map((concert) => (
-        <div key={concert.id || concert.newConcertTitle}>
+        <div 
+          key={concert.id || concert.newConcertTitle} 
+          onClick={() => handleItemClick(concert.newConcertId)} // newConcertId를 활용
+          className="cursor-pointer" // 클릭 가능 표시
+        >
           <MyItem 
             name={concert.newConcertTitle} 
             imgurl={concert.posterUrl} // 이미지 URL 전달

--- a/src/constants/dummyConcerts.ts
+++ b/src/constants/dummyConcerts.ts
@@ -10,20 +10,20 @@ export const dummyConcerts = [
     posterUrl:sampleImg,
     title: '2024 오피셜히게단디즘 내한공연',
     date: '2024-11-30',
-    krName: '오피셜히게단디즘',
+    artistName: '오피셜히게단디즘',
   },
   {
     newConcertId: 2,
     posterUrl: sampleImg1,
     title: '벤슨 분 첫 단독 내한공연',
     date: '2024-01-12',
-    krName: '오피셜히게단디즘',
+    artistName: '오피셜히게단디즘',
   },
   {
     newConcertId: 3,
     posterUrl: sampleImg2,
     title: '찰리푸스 내한공연 ',
     date: '2024-12-07',
-    krName: '오피셜히게단디즘'
+    artistName: '오피셜히게단디즘'
     },
 ];

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,9 +1,34 @@
-import React from 'react';
+import React, { useState } from "react";
+import ArtistTab from "../../components/admin/ArtistTab";
+import ConcertTab from "../../components/admin/ConcertTab";
 
 const AdminPage = () => {
+    const [activeTab, setActiveTab] = useState<"artist" | "concert">("artist");
+
     return (
-        <div className="w-full h-screen flex items-center justify-center bg-gray-100">
-            <h1 className="text-3xl font-bold text-black">관리자 페이지</h1>
+        <div className="w-full h-screen bg-gray-100">
+            <div className="flex justify-center space-x-4 border-b py-4 bg-white shadow">
+                <button
+                    className={`px-4 py-2 ${
+                        activeTab === "artist" ? "border-b-2 border-blue-500 text-blue-500" : ""
+                    }`}
+                    onClick={() => setActiveTab("artist")}
+                >
+                    아티스트 관리
+                </button>
+                <button
+                    className={`px-4 py-2 ${
+                        activeTab === "concert" ? "border-b-2 border-blue-500 text-blue-500" : ""
+                    }`}
+                    onClick={() => setActiveTab("concert")}
+                >
+                    콘서트 관리
+                </button>
+            </div>
+            <div className="p-4">
+                {activeTab === "artist" && <ArtistTab />}
+                {activeTab === "concert" && <ConcertTab />}
+            </div>
         </div>
     );
 };

--- a/src/pages/board/BoardPage.tsx
+++ b/src/pages/board/BoardPage.tsx
@@ -12,6 +12,7 @@ import GlobalSingerHeader from '@/components/global-singer-header';
 import GlobalList from '@/components/global-list';
 import WriteItem from '@/components/write-item';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 // ArtistData 타입 정의
 interface ArtistData {
@@ -22,6 +23,7 @@ interface ArtistData {
 }
 
 const BoardPage: React.FC = () => {
+  const navigate = useNavigate();
   const [articles, setArticles] = useState<Article[]>([]);
   const [artistData, setArtistData] = useState<ArtistData | null>(null);
   const [isEditing, setIsEditing] = useState(false);
@@ -108,6 +110,7 @@ const handleCreateSubmit = async (
 ) => {
   if (!token) {
     alert('로그인이 필요합니다.');
+    
     return;
   }
 
@@ -234,9 +237,16 @@ const handleCreateSubmit = async (
           )}
           <div className="w-full mx-64">
           <button
-            onClick={() => setIsCreating(true)}
-            className="bg-black text-white px-4 py-2 rounded hover:bg-gray-600 "
-          >
+              onClick={() => {
+                if (!token) {
+                  alert('로그인이 필요합니다.');
+                  navigate('/login');
+                  return;
+                }
+                setIsCreating(true);
+              }}
+              className="bg-black text-white px-4 py-2 rounded hover:bg-gray-600"
+            >
             글쓰기
           </button>
         </div>

--- a/src/pages/category/all/AllPage.tsx
+++ b/src/pages/category/all/AllPage.tsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import axios from 'axios';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import CategoryHeader from '@/components/category-header';
 import CategoryCard from '@/components/category-card';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertCard {
+  artistId: string;
+  artistName: ReactNode;
   newConcertId: number; // newConcertId 추가
   posterUrl: string;
   title: string;
@@ -13,12 +16,12 @@ interface ConcertCard {
   endDate: number[];
 }
 
-
 const AllPage = () => {
   // 상태 정의
   const [cardData, setCardData] = useState<ConcertCard[]>([]); // 콘서트 데이터 상태
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null); // 에러 상태
+  const navigate = useNavigate();
 
   // API 호출
   useEffect(() => {
@@ -26,7 +29,14 @@ const AllPage = () => {
       try {
         setLoading(true);
         const response = await axios.get('/api/new-concerts'); // "all" 장르로 요청
-        setCardData(response.data); // 서버에서 받은 데이터 설정
+
+        // 최신순 정렬
+        const sortedData = response.data.sort(
+          (a: { newConcertId: number }, b: { newConcertId: number }) =>
+            b.newConcertId - a.newConcertId
+        );
+
+        setCardData(sortedData); // 정렬된 데이터 설정
       } catch (err) {
         // err가 Error 객체인지 확인 후 처리
         if (err instanceof Error) {
@@ -40,6 +50,12 @@ const AllPage = () => {
     };
     fetchConcerts();
   }, []);
+
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
 
   return (
     <div className='relative bg-white w-full min-h-screen flex justify-center'>
@@ -71,7 +87,14 @@ const AllPage = () => {
                   concertId={card.newConcertId} // 그대로 newConcertId 전달
                   image={card.posterUrl} // 서버에서 받은 이미지가 없으면 기본 이미지 사용
                   title={card.title}
-                  name={card.name}
+                  name={
+                    <span
+                      className="text-[#8c8c8c]  cursor-pointer"
+                      onClick={(e) => handleArtistClick(card.artistId, e)}
+                    >
+                      {card.artistName}
+                    </span>
+                  }
                   startDate={card.startDate}
                   endDate={card.endDate}
                 />

--- a/src/pages/category/hiphop/HiphopPage.tsx
+++ b/src/pages/category/hiphop/HiphopPage.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import CategoryHeader from '@/components/category-header';
 import CategoryCard from '@/components/category-card';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertCard {
-  newConcertId: number; // newConcertId 추가
+  artistId: string;
+  artistName: ReactNode;
+  newConcertId: number;
   posterUrl: string;
   title: string;
   name: string;
@@ -17,12 +20,16 @@ const HiphopPage = () => {
   const [cardData, setCardData] = useState<ConcertCard[]>([]); // 콘서트 데이터 상태
   const [loading, setLoading] = useState(true); // 로딩 상태
   const [error, setError] = useState<string | null>(null); // 에러 상태
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchConcerts = async () => {
       try {
         const response = await axios.get(`/api/new-concerts?genre=HIPHOP`);
-        setCardData(response.data); // API 응답 데이터를 상태에 저장
+        const sortedConcerts = response.data.sort(
+          (a: { newConcertId: number }, b: { newConcertId: number }) => b.newConcertId - a.newConcertId
+        ); // newConcertId 기준으로 내림차순 정렬
+        setCardData(sortedConcerts); // 정렬된 데이터를 상태에 저장
         setLoading(false);
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (err: any) {
@@ -42,6 +49,12 @@ const HiphopPage = () => {
     return <div className='flex justify-center items-center min-h-screen'>Error: {error}</div>;
   }
 
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
+
   return (
     <div className='relative bg-white w-full min-h-screen flex justify-center'>
       <div className='w-full max-w-screen-sm relative'>
@@ -54,11 +67,18 @@ const HiphopPage = () => {
         <div className='grid grid-cols-2 gap-4 px-4 mt-[-20px]'>
           {cardData.map((card) => (
             <CategoryCard
-              key={card.newConcertId} // newConcertId를 키로 사용
-              concertId={card.newConcertId} // 그대로 newConcertId 전달
+              key={card.newConcertId}
+              concertId={card.newConcertId}
               image={card.posterUrl}
               title={card.title}
-              name={card.name}
+              name={
+                <span
+                  className="text-[#8c8c8c]  cursor-pointer"
+                  onClick={(e) => handleArtistClick(card.artistId, e)}
+                >
+                  {card.artistName}
+                </span>
+              }
               startDate={card.startDate}
               endDate={card.endDate}
             />

--- a/src/pages/category/jpop/JpopPage.tsx
+++ b/src/pages/category/jpop/JpopPage.tsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import axios from 'axios';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import CategoryHeader from '@/components/category-header';
 import CategoryCard from '@/components/category-card';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertCard {
+  artistName: ReactNode;
+  artistId: string;
   newConcertId: number; // newConcertId 추가
   posterUrl: string;
   title: string;
@@ -12,16 +15,23 @@ interface ConcertCard {
   startDate: number[];
   endDate: number[];
 }
+
 const JpopPage = () => {
   const [cardData, setCardData] = useState<ConcertCard[]>([]); // 콘서트 데이터 상태
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
 
   useEffect(() => {
     // API 호출
     const fetchConcerts = async () => {
       try {
         const response = await axios.get('/api/new-concerts?genre=JPOP');
-        setCardData(response.data); // 서버에서 받은 데이터로 설정
+        // 데이터 정렬
+        const latestConcerts = response.data.sort(
+          (a: { newConcertId: number }, b: { newConcertId: number }) =>
+            b.newConcertId - a.newConcertId
+        );
+        setCardData(latestConcerts); // 정렬된 데이터로 상태 설정
       } catch (error) {
         console.error('Error fetching data:', error);
       } finally {
@@ -31,6 +41,13 @@ const JpopPage = () => {
 
     fetchConcerts();
   }, []);
+
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
+
 
   return (
     <div className='relative bg-white w-full min-h-screen flex justify-center'>
@@ -56,7 +73,14 @@ const JpopPage = () => {
                 concertId={card.newConcertId} // 그대로 newConcertId 전달
                 image={card.posterUrl}
                 title={card.title}
-                name={card.name}
+                name={
+                  <span
+                    className="text-[#8c8c8c]  cursor-pointer"
+                    onClick={(e) => handleArtistClick(card.artistId, e)}
+                  >
+                    {card.artistName}
+                  </span>
+                }
                 startDate={card.startDate}
                 endDate={card.endDate}
               />

--- a/src/pages/category/new/NewPage.tsx
+++ b/src/pages/category/new/NewPage.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import CategoryHeader from '@/components/category-header';
 import CategoryCard from '@/components/category-card';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertCard {
-  newConcertId: number; // newConcertId 추가
+  artistId: string;
+  artistName: ReactNode;
+  newConcertId: number;
   posterUrl: string;
   title: string;
   name: string;
@@ -13,9 +16,10 @@ interface ConcertCard {
 }
 
 const NewPage = () => {
-  const [cardData, setCardData] = useState<ConcertCard[]>([]); // 콘서트 데이터 상태
+  const [cardData, setCardData] = useState<ConcertCard[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null); // 에러 상태를 문자열 또는 null로 설정
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchCardData = async () => {
@@ -24,13 +28,19 @@ const NewPage = () => {
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }
-        const data = await response.json();
-        setCardData(data);
+        const data: ConcertCard[] = await response.json();
+
+        // 데이터 정렬
+        const sortedData = data.sort(
+          (a, b) => b.newConcertId - a.newConcertId
+        );
+
+        setCardData(sortedData);
       } catch (err) {
         if (err instanceof Error) {
-          setError(err.message); // 'Error' 타입일 때만 message 사용
+          setError(err.message);
         } else {
-          setError('An unknown error occurred'); // 'Error'가 아닐 때의 기본 메시지
+          setError('An unknown error occurred');
         }
       } finally {
         setLoading(false);
@@ -40,36 +50,42 @@ const NewPage = () => {
     fetchCardData();
   }, []);
 
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
+
+
   return (
     <div className='relative bg-white w-full min-h-screen flex justify-center'>
-      {/* 최대 너비 640px로 고정되는 내부 컨테이너 */}
       <div className='w-full max-w-screen-sm relative'>
-        {/* Global Navigation Bar */}
         <div className='relative top-0 left-0 right-0 z-10 bg-black bg-opacity-50'>
           <GlobalNavigationBar />
         </div>
-
-        {/* 카테고리 헤더 - 개별 div로 묶어서 여백 제어 */}
         <div className='py-0'>
           <CategoryHeader title='NEW' />
         </div>
 
-        {/* 로딩 상태 */}
         {loading && <div className='text-center mt-4'>Loading...</div>}
-
-        {/* 에러 상태 */}
         {error && <div className='text-center mt-4 text-red-500'>Error: {error}</div>}
 
-        {/* 카드 목록 */}
         {!loading && !error && cardData.length > 0 ? (
           <div className='grid grid-cols-2 gap-4 px-4 mt-[-20px]'>
             {cardData.map((card) => (
               <CategoryCard
-                key={card.newConcertId} // newConcertId를 키로 사용
-                concertId={card.newConcertId} // 그대로 newConcertId 전달
-                image={card.posterUrl} // 데이터가 없을 경우 샘플 이미지 사용
+                key={card.newConcertId}
+                concertId={card.newConcertId}
+                image={card.posterUrl}
                 title={card.title}
-                name={card.name}
+                name={
+                  <span
+                    className="text-[#8c8c8c]  cursor-pointer"
+                    onClick={(e) => handleArtistClick(card.artistId, e)}
+                  >
+                    {card.artistName}
+                  </span>
+                }
                 startDate={card.startDate}
                 endDate={card.endDate}
               />

--- a/src/pages/category/pop/PopPage.tsx
+++ b/src/pages/category/pop/PopPage.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import axios from 'axios';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import CategoryHeader from '@/components/category-header';
 import CategoryCard from '@/components/category-card';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertCard {
+  artistName: ReactNode;
+  artistId: string;
   newConcertId: number; // newConcertId 추가
   posterUrl: string;
   title: string;
@@ -17,12 +20,20 @@ const PopPage = () => {
   const [cardData, setCardData] = useState<ConcertCard[]>([]); // 콘서트 데이터 상태
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null); // 에러 상태 관리
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchConcerts = async () => {
       try {
         const response = await axios.get('/api/new-concerts?genre=POP');
-        setCardData(response.data);
+        
+        // 콘서트 데이터를 최신순으로 정렬
+        const latestConcerts = response.data.sort(
+          (a: { newConcertId: number }, b: { newConcertId: number }) =>
+            b.newConcertId - a.newConcertId
+        );
+        
+        setCardData(latestConcerts);
       } catch (err) {
         console.error(err); // 콘솔에 에러 출력
         setError('Failed to fetch data');
@@ -30,10 +41,9 @@ const PopPage = () => {
         setLoading(false);
       }
     };
-  
+
     fetchConcerts();
   }, []);
-  
 
   if (loading) {
     return <div className="text-center py-8">Loading...</div>;
@@ -42,6 +52,12 @@ const PopPage = () => {
   if (error) {
     return <div className="text-center py-8 text-red-500">{error}</div>;
   }
+
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
 
   return (
     <div className="relative bg-white w-full min-h-screen flex justify-center">
@@ -65,7 +81,14 @@ const PopPage = () => {
               concertId={card.newConcertId} // 그대로 newConcertId 전달
               image={card.posterUrl} // API에서 받은 이미지 경로
               title={card.title} // API에서 받은 제목
-              name={card.name}   // API에서 받은 이름
+              name={
+                <span
+                  className="text-[#8c8c8c]  cursor-pointer"
+                  onClick={(e) => handleArtistClick(card.artistId, e)}
+                >
+                  {card.artistName}
+                </span>
+              }
               startDate={card.startDate}   // API에서 받은 날짜
               endDate={card.endDate}   // API에서 받은 날짜
             />

--- a/src/pages/category/rnb/RnbPage.tsx
+++ b/src/pages/category/rnb/RnbPage.tsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import CategoryHeader from '@/components/category-header';
 import CategoryCard from '@/components/category-card';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertCard {
+  artistId: string;
+  artistName: ReactNode;
   newConcertId: number; // newConcertId 추가
   posterUrl: string;
   title: string;
@@ -17,6 +20,7 @@ const RnbPage = () => {
   const [cardData, setCardData] = useState<ConcertCard[]>([]); // 콘서트 데이터 상태
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null); // 에러 상태 관리
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchConcerts = async () => {
@@ -24,7 +28,14 @@ const RnbPage = () => {
         setIsLoading(true);
         // API 호출 (쿼리 파라미터를 직접 URL에 추가)
         const response = await axios.get('/api/new-concerts?genre=R&B');
-        setCardData(response.data);
+
+        // 데이터를 정렬한 뒤 상태에 저장
+        const latestConcerts = response.data.sort(
+          (a: { newConcertId: number }, b: { newConcertId: number }) =>
+            b.newConcertId - a.newConcertId
+        );
+
+        setCardData(latestConcerts);
       } catch (err) {
         console.error('Error fetching concerts:', err);
         setError('Failed to load concerts');
@@ -35,6 +46,12 @@ const RnbPage = () => {
 
     fetchConcerts();
   }, []);
+
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
 
   return (
     <div className='relative bg-white w-full min-h-screen flex justify-center'>
@@ -63,7 +80,14 @@ const RnbPage = () => {
                 concertId={card.newConcertId} // 그대로 newConcertId 전달
                 image={card.posterUrl}
                 title={card.title}
-                name={card.name}
+                name={
+                  <span
+                    className="text-[#8c8c8c]  cursor-pointer"
+                    onClick={(e) => handleArtistClick(card.artistId, e)}
+                  >
+                    {card.artistName}
+                  </span>
+                }
                 startDate={card.startDate}
                 endDate={card.endDate}
               />

--- a/src/pages/category/rock/RockPage.tsx
+++ b/src/pages/category/rock/RockPage.tsx
@@ -1,10 +1,13 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import axios from 'axios';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import CategoryHeader from '@/components/category-header';
 import CategoryCard from '@/components/category-card';
+import { useNavigate } from 'react-router-dom';
 
 interface ConcertCard {
+  artistId: string;
+  artistName: ReactNode;
   newConcertId: number; // newConcertId 추가
   posterUrl: string;
   title: string;
@@ -17,13 +20,19 @@ const RockPage = () => {
   const [cardData, setCardData] = useState<ConcertCard[]>([]); // 콘서트 데이터 상태
   const [isLoading, setIsLoading] = useState(true); // 로딩 상태 관리
   const [error, setError] = useState<string | null>(null); // 에러 상태 관리
+  const navigate = useNavigate();
 
   useEffect(() => {
     // API 호출
     const fetchConcerts = async () => {
       try {
         const response = await axios.get('/api/new-concerts?genre=ROCK'); // ROCK 장르로 수정
-        setCardData(response.data); // 응답 데이터를 상태로 설정
+        // 응답 데이터를 정렬하여 상태로 설정
+        const latestConcerts = response.data.sort(
+          (a: { newConcertId: number }, b: { newConcertId: number }) =>
+            b.newConcertId - a.newConcertId
+        );
+        setCardData(latestConcerts); // 정렬된 데이터로 상태 설정
         setIsLoading(false); // 로딩 완료
       } catch (err) {
         console.error(err);
@@ -34,6 +43,12 @@ const RockPage = () => {
 
     fetchConcerts();
   }, []); // 컴포넌트 마운트 시 호출
+
+  // 아티스트 이름 클릭 핸들러
+  const handleArtistClick = (artistId: string, event: React.MouseEvent) => {
+    event.stopPropagation(); // 이벤트 전파 중단
+    navigate(`/artist/${artistId}`);
+  };
 
   return (
     <div className='relative bg-white w-full min-h-screen flex justify-center'>
@@ -63,7 +78,14 @@ const RockPage = () => {
                 concertId={card.newConcertId} // 그대로 newConcertId 전달
                 image={card.posterUrl} // API에서 이미지가 없을 경우 샘플 이미지 사용
                 title={card.title}
-                name={card.name}
+                name={
+                  <span
+                    className="text-[#8c8c8c]  cursor-pointer"
+                    onClick={(e) => handleArtistClick(card.artistId, e)}
+                  >
+                    {card.artistName}
+                  </span>
+                }
                 startDate={card.startDate}
                 endDate={card.endDate}
               />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "module": "esnext",
     "jsx": "react-jsx"
   },
+  "include": ["src/**/*"], // 모든 src 디렉토리 파일 포함
+  "exclude": ["node_modules"],
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },


### PR DESCRIPTION
[feat: 관리자 페이지 기능 구현]
- 아티스트 관리 탭: 아티스트 crud, 과거 콘서트 데이터 동기화
- 콘서트 관리 탭: 내한공연 crud, 예측 셋리스트 생성

[feat: 좋아요 및 글쓰기 버튼에 비로그인 리다이렉트 처리 추가]

[fix: 아티스트 즐겨찾기 버튼 동작 오류 수정]
 -   콘서트 카테고리 목록을 최신순으로 정렬
 -   아티스트 이름 클릭 시 해당 아티스트 페이지로 이동 가능하도록 구현
 -   마이페이지 즐겨찾기 목록에서 관련 페이지로 이동 가능